### PR TITLE
Fix stable-baselines3 notebook for google colab usage (python 3.9)

### DIFF
--- a/scripts/sb3_highway_dqn.ipynb
+++ b/scripts/sb3_highway_dqn.ipynb
@@ -39,10 +39,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "5eeje4O8fviH",
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "id": "5eeje4O8fviH"
    },
    "source": [
     "# Highway with SB3's DQN\n",
@@ -53,19 +50,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install environment and agent\n",
+    "!pip install setuptools==65.5.0\n",
+    "!pip install highway-env==1.5\n",
+    "!pip install stable-baselines3[extra]==1.7.0\n",
+    "\n",
+    "!pip install tensorboardx gym pyvirtualdisplay\n",
+    "!apt-get install -y xvfb python-opengl ffmpeg\n",
+    "\n",
+    "# clone specific branch for script/utils to record and show videos\n",
+    "!git clone https://github.com/eleurent/highway-env.git  --branch \"v1.6\" --single-branch"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
    "metadata": {
     "id": "bzMSuJEOfviP",
     "pycharm": {
-     "is_executing": false,
-     "name": "#%%\n"
+     "is_executing": false
     }
    },
    "source": [
-    "# Install environment and agent\n",
-    "!pip install highway-env\n",
-    "# TODO: we use the bleeding edge version because the current stable version does not support the latest gym>=0.21 versions. Revert back to stable at the next SB3 release.\n",
-    "!pip install git+https://github.com/DLR-RM/stable-baselines3\n",
-    "\n",
     "# Environment\n",
     "import gym\n",
     "import highway_env\n",
@@ -77,11 +88,11 @@
     "%load_ext tensorboard\n",
     "import sys\n",
     "from tqdm.notebook import trange\n",
-    "!pip install tensorboardx gym pyvirtualdisplay\n",
-    "!apt-get install -y xvfb python-opengl ffmpeg\n",
-    "!git clone https://github.com/eleurent/highway-env.git 2> /dev/null\n",
     "sys.path.insert(0, '/content/highway-env/scripts/')\n",
-    "from utils import record_videos, show_videos"
+    "from utils import record_videos, show_videos\n",
+    "\n",
+    "# for suppress warnings\n",
+    "import warnings"
    ],
    "execution_count": null,
    "outputs": []
@@ -90,9 +101,6 @@
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    },
     "id": "_wACJRDjqP-f"
    },
    "source": [
@@ -124,19 +132,22 @@
    },
    "source": [
     "model = DQN('MlpPolicy', \"highway-fast-v0\",\n",
-    "                policy_kwargs=dict(net_arch=[256, 256]),\n",
-    "                learning_rate=5e-4,\n",
-    "                buffer_size=15000,\n",
-    "                learning_starts=200,\n",
-    "                batch_size=32,\n",
-    "                gamma=0.8,\n",
-    "                train_freq=1,\n",
-    "                gradient_steps=1,\n",
-    "                target_update_interval=50,\n",
-    "                exploration_fraction=0.7,\n",
-    "                verbose=1,\n",
-    "                tensorboard_log=\"highway_dqn/\")\n",
-    "model.learn(int(2e4))\n"
+    "            policy_kwargs=dict(net_arch=[256, 256]),\n",
+    "            learning_rate=5e-4,\n",
+    "            buffer_size=15000,\n",
+    "            learning_starts=200,\n",
+    "            batch_size=32,\n",
+    "            gamma=0.8,\n",
+    "            train_freq=1,\n",
+    "            gradient_steps=1,\n",
+    "            target_update_interval=50,\n",
+    "            exploration_fraction=0.7,\n",
+    "            verbose=1,\n",
+    "            tensorboard_log=\"highway_dqn/\")\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter('ignore') # suppress the df append usage warning\n",
+    "    model.learn(int(2e4))\n",
+    "\n"
    ],
    "execution_count": null,
    "outputs": []
@@ -155,10 +166,7 @@
   {
    "cell_type": "code",
    "metadata": {
-    "id": "xOcOP7Of18T2",
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "id": "xOcOP7Of18T2"
    },
    "source": [
     "env = gym.make(\"highway-fast-v0\")\n",


### PR DESCRIPTION
Fix installations issues by installing setup-tools and fixing versions for highway-env, stable-baselines3.
Fix version for cloning of the highway-env to tag v1.6 because that's the last version that uses gym and that the record function is correct.
Add suppress warning because dataframe append is deprecated and this will show the warning messsage once.
