### PR TITLE
Let racetrack_env able to set "other_vehicles" to zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,7 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/highway_env/envs/racetrack_env.py
+++ b/highway_env/envs/racetrack_env.py
@@ -379,31 +379,32 @@ class RacetrackEnv(AbstractEnv):
             self.controlled_vehicles.append(controlled_vehicle)
             self.road.vehicles.append(controlled_vehicle)
 
-        # Front vehicle
-        vehicle = IDMVehicle.make_on_lane(
-            self.road,
-            ("b", "c", lane_index[-1]),
-            longitudinal=rng.uniform(
-                low=0, high=self.road.network.get_lane(("b", "c", 0)).length
-            ),
-            speed=6 + rng.uniform(high=3),
-        )
-        self.road.vehicles.append(vehicle)
-
-        # Other vehicles
-        for i in range(rng.integers(self.config["other_vehicles"])):
-            random_lane_index = self.road.network.random_lane_index(rng)
+        if self.config["other_vehicles"] > 0:
+            # Front vehicle
             vehicle = IDMVehicle.make_on_lane(
                 self.road,
-                random_lane_index,
+                ("b", "c", lane_index[-1]),
                 longitudinal=rng.uniform(
-                    low=0, high=self.road.network.get_lane(random_lane_index).length
+                    low=0, high=self.road.network.get_lane(("b", "c", 0)).length
                 ),
                 speed=6 + rng.uniform(high=3),
             )
-            # Prevent early collisions
-            for v in self.road.vehicles:
-                if np.linalg.norm(vehicle.position - v.position) < 20:
-                    break
-            else:
-                self.road.vehicles.append(vehicle)
+            self.road.vehicles.append(vehicle)
+
+            # Other vehicles
+            for i in range(rng.integers(self.config["other_vehicles"])):
+                random_lane_index = self.road.network.random_lane_index(rng)
+                vehicle = IDMVehicle.make_on_lane(
+                    self.road,
+                    random_lane_index,
+                    longitudinal=rng.uniform(
+                        low=0, high=self.road.network.get_lane(random_lane_index).length
+                    ),
+                    speed=6 + rng.uniform(high=3),
+                )
+                # Prevent early collisions
+                for v in self.road.vehicles:
+                    if np.linalg.norm(vehicle.position - v.position) < 20:
+                        break
+                else:
+                    self.road.vehicles.append(vehicle)


### PR DESCRIPTION
Added an if statement before creating other vehicles to fix the error that occurs when the other_vehicles variable is selected as zero. Now environment let us create only ego vehicle for experiments (with setting other_vehicles to zero.) 

 #521 : 

> I tried to turn this environment to lane following task only by removing the npc vehicle using "other_vehicles": 0 in env.configure but i ended up with some error.