### PR TITLE
Fix definition of "intersection-multi-agent-v1" with MultiAgentWrapper

### DIFF
--- a/highway_env/__init__.py
+++ b/highway_env/__init__.py
@@ -16,6 +16,7 @@ except Exception:  # nosec
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 from gymnasium.envs.registration import register
+from highway_env.envs.common.abstract import MultiAgentWrapper
 
 
 def register_highway_envs():
@@ -56,7 +57,8 @@ def register_highway_envs():
 
     register(
         id="intersection-multi-agent-v1",
-        entry_point="highway_env.envs:TupleMultiAgentIntersectionEnv",
+        entry_point="highway_env.envs:MultiAgentIntersectionEnv",
+        additional_wrappers=(MultiAgentWrapper.wrapper_spec(),),
     )
 
     # lane_keeping_env.py

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -423,6 +423,3 @@ class ContinuousIntersectionEnv(IntersectionEnv):
             }
         )
         return config
-
-
-TupleMultiAgentIntersectionEnv = MultiAgentWrapper(MultiAgentIntersectionEnv)

--- a/highway_env/envs/intersection_env.py
+++ b/highway_env/envs/intersection_env.py
@@ -3,7 +3,7 @@ from typing import Dict, Text, Tuple
 import numpy as np
 
 from highway_env import utils
-from highway_env.envs.common.abstract import AbstractEnv, MultiAgentWrapper
+from highway_env.envs.common.abstract import AbstractEnv
 from highway_env.road.lane import AbstractLane, CircularLane, LineType, StraightLane
 from highway_env.road.regulation import RegulatedRoad
 from highway_env.road.road import RoadNetwork


### PR DESCRIPTION
This PR changes the register of "intersection-multi-agent-v1" to apply the `MultiAgentWrapper` on the register method. 

The previous version is giving an error when importing highway-env with gymnasium 1.0 since `MultiAgentWrapper(MultiAgentIntersectionEnv)` is applying a wrapper to a class instead of an object.