### PR TITLE
Update github release action to use build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,55 @@
-name: Release
+# This workflow will build and (if release) publish Python distributions to PyPI
+# For more information see:
+#   - https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+#   - https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+#
+# derived from https://github.com/Farama-Foundation/PettingZoo/blob/e230f4d80a5df3baf9bd905149f6d4e8ce22be31/.github/workflows/build-publish.yml
+name: build-publish
+
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   release:
-    types:
-      - published
+    types: [published]
 
 jobs:
-  release:
-    name: Deploy release to PyPI
+  build-wheels:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v1
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install dependencies
-        run: pip install wheel
-      - name: Build package
-        run: python setup.py sdist bdist_wheel
-      - name: Upload package
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: python -m pip install --upgrade pip setuptools build
+
+    - name: Build sdist and wheels
+      run: python -m build
+
+    - name: Store wheels
+      uses: actions/upload-artifact@v4
+      with:
+        path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+    - build-wheels
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+    - name: Download dists
+      uses: actions/download-artifact@v4
+      with:
+        name: artifact
+        path: dist
+
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Uses code from Gymnasium that utilises `python -m build` to make the release distribution code. 
