### PR TITLE
Fix LidarObservation Warning

### DIFF
--- a/highway_env/envs/common/observation.py
+++ b/highway_env/envs/common/observation.py
@@ -708,7 +708,7 @@ class LidarObservation(ObservationType):
 
     def trace(self, origin: np.ndarray, origin_velocity: np.ndarray) -> np.ndarray:
         self.origin = origin.copy()
-        self.grid = np.ones((self.cells, 2)) * self.maximum_range
+        self.grid = np.ones((self.cells, 2), dtype=np.float32) * self.maximum_range
 
         for obstacle in self.env.road.vehicles + self.env.road.objects:
             if obstacle is self.observer_vehicle or not obstacle.solid:

--- a/highway_env/utils.py
+++ b/highway_env/utils.py
@@ -392,13 +392,14 @@ def distance_to_rect(line: tuple[np.ndarray, np.ndarray], rect: list[np.ndarray]
     :param rect: a rectangle [A, B, C, D]
     :return: the distance between R and the intersection of the segment RQ with the rectangle ABCD
     """
+    eps = 1e-6
     r, q = line
     a, b, c, d = rect
     u = b - a
     v = d - a
     u, v = u / np.linalg.norm(u), v / np.linalg.norm(v)
-    rqu = (q - r) @ u
-    rqv = (q - r) @ v
+    rqu = (q - r) @ u + eps
+    rqv = (q - r) @ v + eps
     interval_1 = [(a - r) @ u / rqu, (b - r) @ u / rqu]
     interval_2 = [(a - r) @ v / rqv, (d - r) @ v / rqv]
     interval_1 = interval_1 if rqu >= 0 else list(reversed(interval_1))

--- a/tests/envs/test_observations.py
+++ b/tests/envs/test_observations.py
@@ -1,0 +1,27 @@
+import gymnasium as gym
+import pytest
+
+import highway_env
+
+
+gym.register_envs(highway_env)
+
+
+@pytest.mark.parametrize(
+    "observation_config",
+    [
+        {"type": "LidarObservation"},
+    ],
+)
+def test_observation_type(observation_config):
+    env = gym.make("parking-v0", config={"observation": observation_config})
+    env.reset()
+    for _ in range(3):
+        action = env.action_space.sample()
+        obs, _, _, _, _ = env.step(action)
+        assert env.action_space.contains(action)
+        assert env.observation_space.contains(obs)
+    env.close()
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
This PR is to fix these 2 warnings when LidarObservation is used. also a test is added(7fcca61891f491363e0cad9de0df9a0cda618c95).

## Observation Space mismatch

### message
```/home/codespace/.local/lib/python3.12/site-packages/gymnasium-1.1.1-py3.12.egg/gymnasium/utils/passive_env_checker.py:158: UserWarning: WARN: The obs returned by the `step()` method is not within the observation space.```

### reason
Because `dtype` of `self.grid` is not specified, it gets initialized with numpy's default `float64`, which differs from observation space definition`float32`. 

### fix
33f73a34e8825c6fd99ecbe811bfca3180b8db6a

## zero division warning
### message

```
/workspaces/HighwayEnv/highway_env/utils.py:403: RuntimeWarning: divide by zero encountered in scalar divide
    interval_2 = [(a - r) @ v / rqv, (d - r) @ v / rqv]`
```

### reason

dot product gets zero when ego-vehicle and an obstacle are in parallel, such as in case they have zero yaw angle.

### fix

27e594affe09164c21267c4a800003ce1b4491cf
