### PR TITLE
Count out one lidar angle per cell instead of accumulating a float step

### DIFF
--- a/highway_env/envs/common/graphics.py
+++ b/highway_env/envs/common/graphics.py
@@ -264,9 +264,6 @@ class ObservationGraphics:
 
     @classmethod
     def display_grid(cls, lidar_observation, surface):
-        # One angle per cell, counted out rather than reached by accumulating a
-        # float step: `np.arange` with a float step returned 62 angles for 61
-        # cells, and the loop below then indexed `r` past its end.
         cells = lidar_observation.grid.shape[0]
         psi = np.repeat(
             -lidar_observation.angle / 2 + lidar_observation.angle * np.arange(cells),

--- a/highway_env/envs/common/graphics.py
+++ b/highway_env/envs/common/graphics.py
@@ -264,12 +264,12 @@ class ObservationGraphics:
 
     @classmethod
     def display_grid(cls, lidar_observation, surface):
+        # One angle per cell, counted out rather than reached by accumulating a
+        # float step: `np.arange` with a float step returned 62 angles for 61
+        # cells, and the loop below then indexed `r` past its end.
+        cells = lidar_observation.grid.shape[0]
         psi = np.repeat(
-            np.arange(
-                -lidar_observation.angle / 2,
-                2 * np.pi - lidar_observation.angle / 2,
-                2 * np.pi / lidar_observation.grid.shape[0],
-            ),
+            -lidar_observation.angle / 2 + lidar_observation.angle * np.arange(cells),
             2,
         )
         psi = np.hstack((psi[1:], [psi[0]]))

--- a/tests/graphics/test_render.py
+++ b/tests/graphics/test_render.py
@@ -53,9 +53,9 @@ def test_obs_grayscale(env_spec, stack_size=4):
 def test_render_lidar_observation(cells):
     """Rendering a lidar observation draws one sector per cell.
 
-    The angles were reached by accumulating a float step, which for some cell
-    counts produced one angle too many — 62 for 61 cells — and the drawing loop
-    then indexed the ranges array past its end with an IndexError.
+    Before v1.12.2, the angles were calculated by accumulating a float step,
+    which for some cell counts would produced one angle too many and the drawing
+    logic then result in an IndexError.
     """
     env = gym.make(
         "highway-v0",

--- a/tests/graphics/test_render.py
+++ b/tests/graphics/test_render.py
@@ -47,3 +47,28 @@ def test_obs_grayscale(env_spec, stack_size=4):
         env.config["screen_width"],
         env.config["screen_height"],
     )
+
+
+@pytest.mark.parametrize("cells", [3, 16, 60, 61, 62, 123])
+def test_render_lidar_observation(cells):
+    """Rendering a lidar observation draws one sector per cell.
+
+    The angles were reached by accumulating a float step, which for some cell
+    counts produced one angle too many — 62 for 61 cells — and the drawing loop
+    then indexed the ranges array past its end with an IndexError.
+    """
+    env = gym.make(
+        "highway-v0",
+        render_mode="rgb_array",
+        config={"observation": {"type": "LidarObservation", "cells": cells}},
+    ).unwrapped
+    env.reset(seed=0)
+    img = env.render()
+    env.close()
+
+    assert isinstance(img, np.ndarray)
+    assert img.shape == (
+        env.config["screen_height"],
+        env.config["screen_width"],
+        3,
+    )


### PR DESCRIPTION
# Description

Rendering an environment with a `LidarObservation` crashes for some cell counts:

```python
env = gym.make("highway-v0", render_mode="rgb_array",
               config={"observation": {"type": "LidarObservation", "cells": 61}})
env.reset(seed=0)
env.render()
```

```
IndexError: index 122 is out of bounds for axis 0 with size 122
```

`ObservationGraphics.display_grid` builds its angles by accumulating a float
step:

```python
np.arange(-angle / 2, 2 * np.pi - angle / 2, 2 * np.pi / grid.shape[0])
```

`np.arange` with a float step decides the count by division, so rounding
governs whether the endpoint falls inside the interval. For 61 cells it
returns 62 angles. `psi` then holds 124 entries against 122 in `r`, and the
loop indexes `r` past its end. 61 is the only count below 65 where this
happens, which is why the default 16 has always worked.

The angle between cells is already on the observation as
`LidarObservation.angle`, so the sequence can be counted out from the cell
count rather than reached by accumulation. Fixes it for every count.

Fixes # (no issue filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

No visual change to show: for every cell count the old expression got right,
the rendered frame is byte-identical. sha1 of `env.render()` on `highway-v0`,
seed 0:

| cells | main | this branch |
| ----- | ---- | ----------- |
| 16 | `3b6602d98e7c639e` | `3b6602d98e7c639e` |
| 32 | `5e57311494a160f2` | `5e57311494a160f2` |
| 60 | `cc447db4f5998044` | `cc447db4f5998044` |
| 61 | `IndexError` | renders |

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

`tests/graphics/test_render.py` gains a case parametrised over 3, 16, 60, 61,
62 and 123 cells. Only the 61 case fails on `main`; all six pass here. Full
suite locally: 168 passed, 8 skipped.

## Disclosure

I am aware of the AI policy in `CONTRIBUTING.md`. Claude Code, an agentic CLI,
aided me with:

1. exploring `highway_env/envs/common/observation.py` and
   `highway_env/envs/common/graphics.py` to find where the lidar overlay is
   drawn
2. narrowing the crash to the float-step `np.arange` and checking which cell
   counts it gets wrong
3. drafting this change, the test case, and the frame-hash comparison above

The change is two lines and I own it: the failure is a length mismatch between
`psi` and `r`, and the fix removes the accumulation that caused it. Happy to
discuss or adjust.
