### PR TITLE
fix(road): treat count=0 as zero neighbours in close_objects_to

### DIFF
--- a/highway_env/road/road.py
+++ b/highway_env/road/road.py
@@ -455,7 +455,7 @@ class Road:
 
         if sort:
             objects_ = sorted(objects_, key=lambda o: abs(vehicle.lane_distance_to(o)))
-        if count:
+        if count is not None:
             objects_ = objects_[:count]
         return objects_
 

--- a/tests/envs/test_observations.py
+++ b/tests/envs/test_observations.py
@@ -52,5 +52,17 @@ def test_occupancy_grid_shape_no_uint8_overflow():
     env.close()
 
 
+def test_kinematics_vehicles_count_one():
+    # Regression: vehicles_count=1 requests zero neighbours, but a count of
+    # zero was treated as "no limit" and every nearby vehicle was returned.
+    config = {"observation": {"type": "Kinematics", "vehicles_count": 1}}
+    env = gym.make("highway-v0", config=config)
+    obs, _ = env.reset(seed=0)
+    assert env.observation_space.shape == (1, 5)
+    assert obs.shape == (1, 5)
+    assert env.observation_space.contains(obs)
+    env.close()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
# Description

`Road.close_objects_to` truncates its result with `if count:`, so a count of `0` is read as "no limit" and every nearby object is returned. `KinematicObservation` and `ExitObservation` request `count=vehicles_count - 1` neighbours, so `vehicles_count=1` (observe only the ego vehicle) yields an observation of shape `(1 + #nearby, F)` while `observation_space` is `(1, F)`:

```python
env = gym.make("highway-v0", config={"observation": {"type": "Kinematics", "vehicles_count": 1}})
obs, _ = env.reset(seed=0)
env.observation_space.shape, obs.shape   # (1, 5), (10, 5)
env.observation_space.contains(obs)      # False
```

Gymnasium's passive checker warns `The obs returned by the reset() method is not within the observation space` on every reset, and the row count varies with traffic density from step to step.

This truncates whenever a count is given and keeps `None` as "no limit", which is what the only other caller (`AbstractEnv.simplify`) relies on. Default configurations (`vehicles_count=5`) are unaffected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable (no rendering change).

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If my code may add latency, I've tested locally and provided details in description above

`tests/envs/test_observations.py` gains `test_kinematics_vehicles_count_one`, which fails on `main` (`assert (10, 5) == (1, 5)`) and passes here. Locally: `tests/envs` 73 passed, 2 skipped; `tests/road` all passed; a sweep of all 32 registered env ids with default configs shows no out-of-space observations before or after.

## Disclosure

I have read the AI policy in `CONTRIBUTING.md`. This change was produced with Claude Code under my direction. It:

1. swept every registered environment with `observation_space.contains` and read `highway_env/road/road.py` and `highway_env/envs/common/observation.py` to locate the truncation
2. checked `git blame` / `git log -L` and the issue and PR history around `close_objects_to` (#483) to confirm `count=0` was never given a "no limit" meaning
3. drafted the one-line change, the regression test and this description

The change is one line and I take responsibility for it: `None` is the documented "no limit" sentinel and `0` is a legitimate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
