### PR TITLE
fix(road): emit class_path from PolyLane.to_config

### DIFF
--- a/highway_env/road/lane.py
+++ b/highway_env/road/lane.py
@@ -400,6 +400,7 @@ class PolyLaneFixedWidth(AbstractLane):
         speed_limit: float = 20,
         priority: int = 0,
     ) -> None:
+        self.lane_points = lane_points
         self.curve = LinearSpline2D(lane_points)
         self.length = self.curve.length
         self.width = width
@@ -430,11 +431,9 @@ class PolyLaneFixedWidth(AbstractLane):
 
     def to_config(self) -> dict:
         return {
-            "class_name": self.__class__.__name__,
+            "class_path": get_class_path(self.__class__),
             "config": {
-                "lane_points": _to_serializable(
-                    [_to_serializable(p.position) for p in self.curve.poses]
-                ),
+                "lane_points": _to_serializable(self.lane_points),
                 "width": self.width,
                 "line_types": self.line_types,
                 "forbidden": self.forbidden,
@@ -518,18 +517,13 @@ class PolyLane(PolyLaneFixedWidth):
 
     def to_config(self) -> dict:
         config = super().to_config()
-
-        ordered_boundary_points = _to_serializable(
-            [_to_serializable(p.position) for p in reversed(self.left_boundary.poses)]
+        config["config"]["left_boundary_points"] = _to_serializable(
+            [_to_serializable(p) for p in self.left_boundary_points]
         )
-        ordered_boundary_points += _to_serializable(
-            [_to_serializable(p.position) for p in self.right_boundary.poses]
+        config["config"]["right_boundary_points"] = _to_serializable(
+            [_to_serializable(p) for p in self.right_boundary_points]
         )
-
-        config["class_name"] = self.__class__.__name__
-        config["config"]["ordered_boundary_points"] = ordered_boundary_points
         del config["config"]["width"]
-
         return config
 
 

--- a/tests/road/test_road.py
+++ b/tests/road/test_road.py
@@ -46,6 +46,41 @@ def test_network_to_from_config(net):
     assert len(net.graph) == len(net_2.graph)
 
 
+def test_polylane_network_to_from_config():
+    # Regression: PolyLane.to_config stored class_name, but lane_from_config
+    # reads class_path, so RoadNetwork.from_config crashed with KeyError.
+    lane = CircularLane(
+        center=[0, 0],
+        radius=10,
+        start_phase=0,
+        end_phase=3.14,
+    )
+    num_samples = int(lane.length / 5)
+    sampled_centreline = [
+        lane.position(longitudinal=lon, lateral=0)
+        for lon in np.linspace(0, lane.length, num_samples)
+    ]
+    sampled_left_boundary = [
+        lane.position(longitudinal=lon, lateral=0.5 * lane.width_at(longitudinal=lon))
+        for lon in np.linspace(0, lane.length, num_samples)
+    ]
+    sampled_right_boundary = [
+        lane.position(longitudinal=lon, lateral=-0.5 * lane.width_at(longitudinal=lon))
+        for lon in np.linspace(0, lane.length, num_samples)
+    ]
+    polylane = PolyLane(
+        lane_points=sampled_centreline,
+        left_boundary_points=sampled_left_boundary,
+        right_boundary_points=sampled_right_boundary,
+    )
+    net = RoadNetwork()
+    net.add_lane("a", "b", polylane)
+    net_2 = RoadNetwork.from_config(net.to_config())
+    restored = net_2.get_lane(("a", "b", 0))
+    assert isinstance(restored, PolyLane)
+    assert restored.length == pytest.approx(polylane.length)
+
+
 def test_polylane():
     lane = CircularLane(
         center=[0, 0],


### PR DESCRIPTION
# Description

`PolyLane.to_config` wrote `class_name`, but `lane_from_config` only reads `class_path`. `RoadNetwork.from_config` therefore dies with `KeyError: 'class_path'` as soon as the graph contains a `PolyLane` or `PolyLaneFixedWidth`. StraightLane and CircularLane already emit `class_path`.

```python
from highway_env.road.lane import PolyLaneFixedWidth, lane_from_config
lane_from_config(PolyLaneFixedWidth([(0, 0), (10, 0)]).to_config())
# KeyError: 'class_path'
```

Also serialize the constructor points instead of the 1 m spline samples, so a round-trip keeps the original length.

`uv run --frozen pytest tests/road/test_road.py tests/road/test_spline.py`
